### PR TITLE
#113 categorias tipos problema usuario externo

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-prettier": "^4.0.0",
     "jest": "28.1.3",
+    "jest-sonar": "^0.2.16",
     "prettier": "^2.3.2",
     "source-map-support": "^0.5.20",
     "supertest": "^6.1.3",
@@ -63,8 +64,7 @@
     "ts-loader": "^9.2.3",
     "ts-node": "^10.0.0",
     "tsconfig-paths": "4.1.0",
-    "typescript": "^4.7.4",
-    "jest-sonar": "^0.2.12"
+    "typescript": "^4.7.4"
   },
   "jest": {
     "moduleFileExtensions": [

--- a/src/problem-category/dto/create-problem-category.dto.ts
+++ b/src/problem-category/dto/create-problem-category.dto.ts
@@ -4,5 +4,6 @@ export class CreateProblemCategoryDto {
   name: string;
   @IsString({ message: 'Informe uma descrição válida' })
   description: string;
+  visible_user_external: boolean;
   problem_types_ids: string[];
 }

--- a/src/problem-category/dto/update-problem-category.dto.ts
+++ b/src/problem-category/dto/update-problem-category.dto.ts
@@ -6,5 +6,6 @@ export class UpdateProblemCategoryDto extends PartialType(
 ) {
   name: string;
   description: string;
+  visible_user_external: boolean;
   problem_types_ids: string[];
 }

--- a/src/problem-category/entities/problem-category.entity.ts
+++ b/src/problem-category/entities/problem-category.entity.ts
@@ -22,6 +22,9 @@ export class ProblemCategory extends BaseEntity {
   @Column({ nullable: true })
   description: string;
 
+  @Column()
+  visible_user_external: boolean;
+
   @OneToMany(
     () => ProblemType,
     (problem_type: ProblemType) => problem_type.problem_category,

--- a/src/problem-category/problem-category.controller.spec.ts
+++ b/src/problem-category/problem-category.controller.spec.ts
@@ -13,11 +13,13 @@ describe('ProblemCategoryController', () => {
 
   const mockCreateProblemCategoryDto: CreateProblemCategoryDto = {
     name: 'mockName',
+    visible_user_external: false,
     problem_types_ids: ['mockProblemType1', 'mockProblemType2'],
     description: 'mockDescription',
   };
   const mockUpdateProblemCategoryDto: UpdateProblemCategoryDto = {
     name: 'UpdateMockName',
+    visible_user_external: false,
     problem_types_ids: ['mockProblemType1', 'mockProblemType2'],
     description: 'mockDescription',
   };

--- a/src/problem-category/problem-category.service.spec.ts
+++ b/src/problem-category/problem-category.service.spec.ts
@@ -16,11 +16,13 @@ describe('ProblemCategoryService', () => {
     
     const mockProblemType = {
         name: 'mockProblemType',
+        visible_user_external: false,
         description: 'mockDescription',
     };
     
     const mockProblemCategory = {
         name: 'mockProblemCategory',
+        visible_user_external: false,
         desciption: 'mockDescription',
         problem_types: [mockProblemType],
     };
@@ -29,12 +31,14 @@ describe('ProblemCategoryService', () => {
 
     const mockCreateProblemCategoryDto = {
         name: 'mockProblemCategory',
+        visible_user_external: false,
         description: 'mockDescription',
         problem_types_ids: ['123'],
     };
 
     const mockUpdateProblemCategoryDto = {
         name: 'mockProblemCategory',
+        visible_user_external: false,
         description: 'mockDescription',
         problem_types_ids: ['123'],
     };

--- a/src/problem-types/dto/createProblem-type.dto.ts
+++ b/src/problem-types/dto/createProblem-type.dto.ts
@@ -9,5 +9,7 @@ export class CreateProblemTypeDto {
   @IsNotEmpty()
   problem_category_id: string;
 
+  visible_user_external: boolean;
+
   issues_ids: string[];
 }

--- a/src/problem-types/dto/updateProblem-type.dto.ts
+++ b/src/problem-types/dto/updateProblem-type.dto.ts
@@ -7,5 +7,7 @@ export class UpdateProblemTypeDto {
   @IsString()
   problem_category_id: string;
 
+  visible_user_external: boolean;
+
   issues_ids: string[];
 }

--- a/src/problem-types/entities/problem-type.entity.ts
+++ b/src/problem-types/entities/problem-type.entity.ts
@@ -19,6 +19,9 @@ export class ProblemType extends BaseEntity {
   @Column()
   name: string;
 
+  @Column()
+  visible_user_external: boolean;
+
   @ManyToOne(
     () => ProblemCategory,
     (problem_category: ProblemCategory) => problem_category.problem_types,

--- a/src/problem-types/problem-types.controller.spec.ts
+++ b/src/problem-types/problem-types.controller.spec.ts
@@ -19,12 +19,14 @@ describe('ProblemTypesController', () => {
   const mockCreateProblemTypeDto: CreateProblemTypeDto = {
     name: 'mockProblemType',
     problem_category_id: '123',
+    visible_user_external: false,
     issues_ids: ['456', '789'],
   };
 
   const mockUpdateProblemTypeDto: UpdateProblemTypeDto = {
     name: 'mockProblemType',
     problem_category_id: '123',
+    visible_user_external: false,
     issues_ids: ['456', '789'],
   };
   const mockProblemTypesService = {

--- a/src/problem-types/problem-types.service.spec.ts
+++ b/src/problem-types/problem-types.service.spec.ts
@@ -40,12 +40,14 @@ describe('ProblemTypesService', () => {
 
   const mockCreateProblemTypeDto = {
     name: 'mockProblemType',
+    visible_user_external: false,
     problem_category_id: '123',
     issues_ids: ['456', '789'],
   };
 
   const mockUpdateProblemTypeDto = {
     name: 'mockProblemType',
+    visible_user_external: false,
     problem_category_id: '123',
     issues_ids: ['456', '789'],
   };

--- a/yarn.lock
+++ b/yarn.lock
@@ -3238,7 +3238,7 @@ jest-snapshot@^28.1.3:
     pretty-format "^28.1.3"
     semver "^7.3.5"
 
-jest-sonar@^0.2.12:
+jest-sonar@^0.2.16:
   version "0.2.16"
   resolved "https://registry.yarnpkg.com/jest-sonar/-/jest-sonar-0.2.16.tgz#58d2e150dbcb9a3c781c78ae8fda327ea2439b4c"
   integrity sha512-ES6Z9BbIVDELtbz+/b6pv41B2qOfp38cQpoCLqei21FtlkG/GzhyQ0M3egEIM+erpJOkpRKM8Tc8/YQtHdiTXA==


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# Pull Request

## 📖 Description
Adicionando propriedade de visualização por usuário externo das categorias e tipos de problema.
<!---
Provide some background and a description of your work.
-->

### 🎫 Issues
Resolve [Issue #113](https://github.com/fga-eps-mds/2023-1-Schedula-Doc/issues/113)
<!---
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes
Agora é possível utilizar uma propriedade para determinar se uma categoria ou tipo de problema pode ser visualizado por um usuário externo.
<!---
Provide some notes for reviewers to help them provide targeted feedback.
-->

## 📑 Test Plan
Utilizar a branch "#113-Categorias_Tipos_Problema_Usuario_Externo" no Front.
Verificar a presença da propriedade "visible_user_external" na categoria e no tipo de problema, e se pode ser manipulada em verdadeiro ou falso.
<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->
